### PR TITLE
Fix code-generated figures in PDFs

### DIFF
--- a/R/render_pdf.R
+++ b/R/render_pdf.R
@@ -51,40 +51,41 @@ render_pdf <- function(path_in, ..., quiet = FALSE) {
 }
 
 construct_pandoc_args2 <- function(path_in, output, to = "pdf", ...) {
-  exts <- paste(
-    "smart",
-    "auto_identifiers",
-    "autolink_bare_uris",
-    "emoji",
-    "footnotes",
-    "inline_notes",
-    "tex_math_dollars",
-    "tex_math_single_backslash",
-    "markdown_in_html_blocks",
-    "yaml_metadata_block",
-    "header_attributes",
-    "native_divs",
-    sep = "+"
-  )
-  from <- paste0("markdown", "-hard_line_breaks", "+", exts)
-  lua_filter <- rmarkdown::pkg_file_lua("lesson.lua", "sandpaper")
+  # exts <- paste(
+  #   "smart",
+  #   "auto_identifiers",
+  #   "autolink_bare_uris",
+  #   "emoji",
+  #   "footnotes",
+  #   "inline_notes",
+  #   "tex_math_dollars",
+  #   "tex_math_single_backslash",
+  #   "markdown_in_html_blocks",
+  #   "yaml_metadata_block",
+  #   "header_attributes",
+  #   "native_divs",
+  #   sep = "+"
+  # )
+  # from <- paste0("markdown", "-hard_line_breaks", "+", exts)
+  from <- "markdown"
+  # lua_filter <- rmarkdown::pkg_file_lua("lesson.lua", "sandpaper")
   list(
     input   = path_in,
     output  = output,
     from    = from,
     to      = to,
-    options = c(
-      "--preserve-tabs",
-      "--indented-code-classes=sh",
-      "--section-divs",
-      "--mathjax",
-      "--template",
-      "eisvogel",
-      "--listings",
-      "--lua-filter",
-      lua_filter,
-      ...
-    ),
+    # options = c(
+    #   "--preserve-tabs",
+    #   "--indented-code-classes=sh",
+    #   "--section-divs",
+    #   "--mathjax",
+    #   "--template",
+    #   "eisvogel",
+    #   "--listings",
+    #   "--lua-filter",
+    #   lua_filter,
+    #   ...
+    # ),
     verbose = FALSE
   )
 }

--- a/R/render_pdf.R
+++ b/R/render_pdf.R
@@ -51,41 +51,40 @@ render_pdf <- function(path_in, ..., quiet = FALSE) {
 }
 
 construct_pandoc_args2 <- function(path_in, output, to = "pdf", ...) {
-  # exts <- paste(
-  #   "smart",
-  #   "auto_identifiers",
-  #   "autolink_bare_uris",
-  #   "emoji",
-  #   "footnotes",
-  #   "inline_notes",
-  #   "tex_math_dollars",
-  #   "tex_math_single_backslash",
-  #   "markdown_in_html_blocks",
-  #   "yaml_metadata_block",
-  #   "header_attributes",
-  #   "native_divs",
-  #   sep = "+"
-  # )
-  # from <- paste0("markdown", "-hard_line_breaks", "+", exts)
-  from <- "markdown"
-  # lua_filter <- rmarkdown::pkg_file_lua("lesson.lua", "sandpaper")
+  exts <- paste(
+    "smart",
+    "auto_identifiers",
+    "autolink_bare_uris",
+    "emoji",
+    "footnotes",
+    "inline_notes",
+    "tex_math_dollars",
+    "tex_math_single_backslash",
+    "markdown_in_html_blocks",
+    "yaml_metadata_block",
+    "header_attributes",
+    "native_divs",
+    sep = "+"
+  )
+  from <- paste0("markdown", "-hard_line_breaks", "+", exts)
+  lua_filter <- rmarkdown::pkg_file_lua("lesson.lua", "sandpaper")
   list(
     input   = path_in,
     output  = output,
     from    = from,
     to      = to,
-    # options = c(
-    #   "--preserve-tabs",
-    #   "--indented-code-classes=sh",
-    #   "--section-divs",
-    #   "--mathjax",
-    #   "--template",
-    #   "eisvogel",
-    #   "--listings",
-    #   "--lua-filter",
-    #   lua_filter,
-    #   ...
-    # ),
+    options = c(
+      "--preserve-tabs",
+      "--indented-code-classes=sh",
+      "--section-divs",
+      "--mathjax",
+      "--template",
+      "eisvogel",
+      "--listings",
+      "--lua-filter",
+      lua_filter,
+      ...
+    ),
     verbose = FALSE
   )
 }

--- a/R/utils-callr.R
+++ b/R/utils-callr.R
@@ -43,7 +43,6 @@ callr_build_episode_md <- function(path, hash, workenv, outpath, workdir, root, 
   knitr::opts_chunk$set(
     error         = error,
     comment       = "",
-    fig.align     = "center",
     class.output  = "output",
     class.error   = "error",
     class.warning = "warning",


### PR DESCRIPTION
Closes #20 
The culprit was the `fig.align` option in the knitr options, which causes `knitr` to use html tags for figures instead of the markdown `![]` syntax. By simply removing the option, this should be resolved.