### PR TITLE
Add the `aio_pdf` global parameter for varnish

### DIFF
--- a/R/utils-varnish.R
+++ b/R/utils-varnish.R
@@ -87,9 +87,11 @@ set_globals <- function(path) {
     "instructors")
   pkg_versions <- varnish_vars()
 
+  cfg <- get_config(path)
   learner_globals$set(key = NULL,
     c(list(
       aio = TRUE,
+      aio_pdf = cfg$pdf,
       instructor = FALSE,
       sidebar = learner_sidebar,
       more = paste(learner$extras, collapse = ""),
@@ -99,6 +101,7 @@ set_globals <- function(path) {
   instructor_globals$set(key = NULL,
     c(list(
       aio = TRUE,
+      aio_pdf = cfg$pdf,
       instructor = TRUE,
       sidebar = instructor_sidebar,
       more = paste(instructor$extras, collapse = ""),
@@ -124,4 +127,3 @@ clear_globals <- function() {
   instructor_globals$clear()
   this_metadata$clear()
 }
-


### PR DESCRIPTION
See https://github.com/LearnToDiscover/varnish/issues/4

Now, whenever `pdf: TRUE` in the `config.yaml` of a lesson, an "All in one" PDF will be generated (see #27) and a link is displayed in the sidebar (see LearnToDiscover/varnish#5).