### PR TITLE
Avoid duplicate caching

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -36,7 +36,7 @@ jobs:
       R_REMOTES_NO_ERRORS_FROM_WARNINGS: true
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - uses: r-lib/actions/setup-pandoc@v2
 

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -28,13 +28,12 @@ jobs:
       matrix:
         config:
           ## Run CI only on ubuntu-latest as this is the os used to build lessons
-          - {os: ubuntu-latest, cache: '~/.local/share/renv', r: 'release', cov: 'true'}
+          - {os: ubuntu-latest, r: 'release', cov: 'true'}
 
     env:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
       R_KEEP_PKG_SOURCE: yes
       R_REMOTES_NO_ERRORS_FROM_WARNINGS: true
-      RENV_PATHS_ROOT: ${{ matrix.config.cache }}
 
     steps:
       - name: Record Linux Version
@@ -76,25 +75,6 @@ jobs:
           extra-packages: any::rcmdcheck
           needs: check
 
-      - name: "Restore {renv} cache"
-        if: runner.os != 'Windows'
-        uses: actions/cache@v3
-        with:
-          path: ${{ env.RENV_PATHS_ROOT }}
-          key: ${{ runner.os }}-${{ env.OS_VERSION }}-renv-${{ runner.r }}-${{ hashFiles('.github/workflows/R-CMD-check.yaml') }}
-          restore-keys: |
-            ${{ runner.os }}-${{ env.OS_VERSION }}-renv-${{ runner.r }}-
-
-      - name: "Prime {renv} Cache"
-        if: runner.os != 'Windows'
-        run: |
-          renv::settings$snapshot.type("explicit")
-          renv::init(bioconductor = TRUE)
-          system('sudo rm -rf renv.lock renv .Rprofile')
-          system('git clean -fd -e .github')
-          system('git restore .')
-        shell: Rscript {0}
-
       - name: "Session info"
         run: |
           options(width = 100)
@@ -104,14 +84,5 @@ jobs:
 
       - name: "Check"
         uses: r-lib/actions/check-r-package@v2
-        if: runner.os != 'Windows'
-        with:
-          upload-snapshots: true
-
-      - name: "Check"
-        uses: r-lib/actions/check-r-package@v2
-        if: runner.os == 'Windows'
-        env:
-          RENV_PATHS_ROOT: ~
         with:
           upload-snapshots: true

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -36,31 +36,12 @@ jobs:
       R_REMOTES_NO_ERRORS_FROM_WARNINGS: true
 
     steps:
-      - name: Record Linux Version
-        if: runner.os == 'Linux'
-        run: |
-          echo "OS_VERSION=`lsb_release -sr`" >> $GITHUB_ENV
-          mkdir -p "${{ runner.temp }}/sandbox/"
-          echo "RENV_PATHS_SANDBOX=${{ runner.temp }}/sandbox/" >> $GITHUB_ENV
-
-      - name: "Windows: prevent autocrlf"
-        if: runner.os == 'Windows'
-        run: git config --global core.autocrlf false
-        shell: bash
-
       - uses: actions/checkout@v3
 
       - uses: r-lib/actions/setup-pandoc@v2
 
       - name: "Set up Chrome" # for PDF rendering
         uses: browser-actions/setup-chrome@v1.6.0
-
-      - name: "Windows: setup TMPDIR"
-        if: runner.os == 'Windows'
-        run: |
-          git config --global core.autocrlf true # reset setting to prevent errors downstream
-          echo "TMPDIR=${{ runner.temp }}" >> $GITHUB_ENV
-        shell: bash
 
       - name: "Setup R"
         uses: r-lib/actions/setup-r@v2

--- a/.github/workflows/pkgdown.yaml
+++ b/.github/workflows/pkgdown.yaml
@@ -20,7 +20,7 @@ jobs:
     env:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - uses: r-lib/actions/setup-pandoc@v2
 

--- a/.github/workflows/pr-commands.yaml
+++ b/.github/workflows/pr-commands.yaml
@@ -14,7 +14,7 @@ jobs:
     env:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - uses: r-lib/actions/pr-fetch@v2
         with:

--- a/.github/workflows/test-coverage.yaml
+++ b/.github/workflows/test-coverage.yaml
@@ -17,7 +17,7 @@ jobs:
       OS_VERSION: 1
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - uses: r-lib/actions/setup-r@v2
         with:

--- a/.github/workflows/test-coverage.yaml
+++ b/.github/workflows/test-coverage.yaml
@@ -14,7 +14,6 @@ jobs:
     runs-on: ubuntu-latest
     env:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
-      RENV_PATHS_ROOT: ~/.local/share/renv
       OS_VERSION: 1
 
     steps:
@@ -59,23 +58,6 @@ jobs:
         with:
           extra-packages: any::covr
           needs: coverage
-
-      - name: Restore {renv} cache
-        uses: actions/cache@v3
-        with:
-          path: ${{ env.RENV_PATHS_ROOT }}
-          key: ${{ runner.os }}-${{ env.OS_VERSION }}-renv-${{ runner.r }}-${{ hashFiles('.github/workflows/R-CMD-check.yaml') }}
-          restore-keys: |
-            ${{ runner.os }}-${{ env.OS_VERSION }}-renv-${{ runner.r }}-
-
-      - name: Prime {renv} Cache
-        run: |
-          renv::settings$snapshot.type("explicit")
-          renv::init(bioconductor = TRUE)
-          system('rm -rf renv .Rprofile')
-          system('git clean -fd -e .github')
-          system('git restore .')
-        shell: Rscript {0}
 
       - name: Test coverage
         run: |

--- a/.github/workflows/update-dots.yaml
+++ b/.github/workflows/update-dots.yaml
@@ -2,7 +2,7 @@ name: Render Dotfiles
 
 on:
   push:
-    paths: 
+    paths:
       - vignettes/articles/img/*dot
       - .github/workflows/update-docs.yaml
 
@@ -11,8 +11,8 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2.5.0
-      
+      - uses: actions/checkout@v4
+
       - name: Setup Graphviz
         uses: ts-graphviz/setup-graphviz@v1
 


### PR DESCRIPTION
Remove the custom `renv` caching as `r-lib/actions/setup-r-dependencies` already takes care of caching.
See also https://github.com/carpentries/sandpaper/issues/591

This should reduce the amount of storage used by the GitHub Actions caches.